### PR TITLE
Refresh seasonal content for summer

### DIFF
--- a/src/pages/families/after-school-activities.astro
+++ b/src/pages/families/after-school-activities.astro
@@ -18,6 +18,26 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
       <p class="text-gray-400 text-center">A more complete and searchable list of activities can be found at <a href="activities" class="hover:text-grey-800">http://dertown.org/family/activities</a>.</p>
     </div>
 
+    <!-- Upcoming Signup Callout -->
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-6">
+      <div class="bg-amber-50 border border-amber-200 rounded-lg p-5">
+        <h3 class="font-semibold text-amber-900 flex items-center gap-2 mb-3">
+          <span class="material-symbols-outlined">calendar_month</span>
+          Upcoming &amp; Open Signups
+        </h3>
+        <ul class="space-y-2 text-sm text-amber-800">
+          <li class="flex items-start gap-2">
+            <span class="material-symbols-outlined text-base mt-0.5">downhill_skiing</span>
+            <span><strong>PVNT Summer/Fall Roller Ski</strong> — Signups open now for the summer/fall session (Tuesdays &amp; Thursdays 3:30–5:30pm). <a href="https://www.skiplain.com/pvnt-summer" target="_blank" class="underline">Register at skiplain.com</a></span>
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="material-symbols-outlined text-base mt-0.5">groups</span>
+            <span><strong>Cub Scouts</strong> — Fall is the best time to join, but new scouts are welcome year-round.</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
     <!-- Quick Navigation -->
     <div class="border-b border-gray-200 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
       <div class="flex flex-wrap justify-center gap-2">
@@ -53,26 +73,26 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
               <LinkBox
                 title="Cub Scouts"
                 text="All-gender scouting program building character, citizenship, and fitness through fun activities and outdoor adventures."
-                subtext="Every other Thursday after school with monthly weekend activities."
+                subtext="Every other Thursday after school with monthly weekend activities. Fall is the best time to sign up, but new scouts are welcome anytime."
                 link="https://drive.google.com/file/d/1dciVqWZcTV1rLMoHLIIzBQfY09T7K664/view?usp=drive_link"
                 icon="groups"
                 external={false}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--yellow status-badge--md">Fall (best) / Anytime</span>
               </div>
             </div>
             <div class="relative">
               <LinkBox
                 title="Plain Valley Nordic Devo Team"
-                text="Cross-country skiing program focused on developing a passion for playing outdoors through both dry land and winter activities. Skills are acquired through play and reinforced with small drills."
-                subtext="Summer/Fall: roller skiing, agility courses, hill bounding, trail runs and a fun camp. $120 with scholarship available. Tuesdays & Thursdays 3:30-5:30. Winter: Information forthcoming."
+                text="Cross-country skiing program for students from Peshastin-Dryden, Alpine Lakes, and Icicle River Middle School. Develops a passion for playing outdoors through dry land and winter activities — skills acquired through play and reinforced with small drills."
+                subtext="Summer/Fall: roller skiing, agility courses, hill bounding, trail runs and a fun camp. $120 with scholarship available. Tuesdays & Thursdays 3:30–5:30."
                 link="https://www.skiplain.com/pvnt-summer"
                 icon="downhill_skiing"
                 external={true}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">WINTER</span>
+                <span class="status-badge status-badge--yellow status-badge--md">Summer/Fall</span>
               </div>
             </div>
           </div>
@@ -86,7 +106,7 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
         <SectionHeader
           title="Alpine Lakes Elementary"
           icon="school"
-    />
+        />
         <div class="bg-white rounded-lg shadow-lg p-6">
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div class="relative">
@@ -145,33 +165,33 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
               <LinkBox
                 title="Cub Scouts"
                 text="All-gender scouting program building character, citizenship, and fitness through fun activities and outdoor adventures."
-                subtext="Every other Thursday after school with monthly weekend activities."
+                subtext="Every other Thursday after school with monthly weekend activities. Fall is the best time to sign up, but new scouts are welcome anytime."
                 link="https://drive.google.com/file/d/1dciVqWZcTV1rLMoHLIIzBQfY09T7K664/view?usp=drive_link"
                 icon="groups"
                 external={false}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--yellow status-badge--md">Fall (best) / Anytime</span>
               </div>
             </div>
             <div class="relative">
               <LinkBox
                 title="Plain Valley Nordic Devo Team"
-                text="Cross-country skiing program focused on developing a passion for playing outdoors through both dry land and winter activities. Skills are acquired through play and reinforced with small drills."
-                subtext="Summer/Fall: roller skiing, agility courses, hill bounding, trail runs and a fun camp. $120 with scholarship available. Tuesdays & Thursdays 3:30-5:30. Winter: Information forthcoming."
+                text="Cross-country skiing program for students from Peshastin-Dryden, Alpine Lakes, and Icicle River Middle School. Develops a passion for playing outdoors through dry land and winter activities — skills acquired through play and reinforced with small drills."
+                subtext="Summer/Fall: roller skiing, agility courses, hill bounding, trail runs and a fun camp. $120 with scholarship available. Tuesdays & Thursdays 3:30–5:30."
                 link="https://www.skiplain.com/pvnt-summer"
                 icon="downhill_skiing"
                 external={true}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--yellow status-badge--md">Summer/Fall</span>
               </div>
             </div>
             <div class="relative">
               <LinkBox
                 title="Ski Club"
-                text="Weekly skiing program for students to develop skills and enjoy winter sports in the beautiful Ski Hill."
-                subtext="Wednesdays after school in January/February. Equipment, transportation to ski hill, and LWSC passes provided. Details to be announced in December."
+                text="Weekly skiing program for students to develop skills and enjoy winter sports at Ski Hill."
+                subtext="Wednesdays after school in January/February. Equipment, transportation to ski hill, and LWSC passes provided. Details announced in December."
                 link="https://sites.google.com/view/pd-alpinelakespto/activities"
                 icon="ac_unit"
                 external={true}
@@ -243,20 +263,20 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
                 external={true}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--yellow status-badge--md">Fall</span>
               </div>
             </div>
             <div class="relative">
               <LinkBox
                 title="Sustainability Club"
                 text="Environmental awareness and sustainability program where students learn about conservation, recycling, and environmental stewardship."
-                subtext="Mondays after school:3-4PM"
+                subtext="Mondays after school 3–4PM"
                 link="https://www.cascadesd.org/o/irms/page/sustainability-club"
                 icon="eco"
                 external={true}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--blue status-badge--md">Ongoing</span>
               </div>
             </div>
             <div class="relative">
@@ -275,14 +295,14 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
             <div class="relative">
               <LinkBox
                 title="Plain Valley Nordic Devo Team"
-                text="Cross-country skiing program focused on developing a passion for playing outdoors through both dry land and winter activities. Skills are acquired through play and reinforced with small drills."
-                subtext="Summer/Fall: roller skiing, agility courses, hill bounding, trail runs and a fun camp. $120 with scholarship available. Tuesdays & Thursdays 3:30-5:30. Winter: Information forthcoming."
+                text="Cross-country skiing program for students from Peshastin-Dryden, Alpine Lakes, and Icicle River Middle School. Develops a passion for playing outdoors through dry land and winter activities — skills acquired through play and reinforced with small drills."
+                subtext="Summer/Fall: roller skiing, agility courses, hill bounding, trail runs and a fun camp. $120 with scholarship available. Tuesdays & Thursdays 3:30–5:30."
                 link="https://www.skiplain.com/pvnt-summer"
                 icon="downhill_skiing"
                 external={true}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--yellow status-badge--md">Summer/Fall</span>
               </div>
             </div>
             <div class="relative">
@@ -295,27 +315,27 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
                 external={false}
               />
               <div class="absolute top-2 right-2">
-                <span class="status-badge status-badge--green status-badge--md">OPEN</span>
+                <span class="status-badge status-badge--blue status-badge--md">Year-round</span>
               </div>
             </div>
             <div class="relative">
-                <LinkBox
-                  title="Leavenworth Library"
-                  text="Spend your afternoons at the library reading, doing homework, and playing games."
-                  subtext="For responsible children who can work independently. Tuesday thru Friday."
-                  link="https://www.ncwlibraries.org/locations/leavenworth-public-library/"
-                  icon="book"
-                  external={false}
-                />
-                <div class="absolute top-2 right-2">
-                  <span class="status-badge status-badge--blue status-badge--md">Ongoing</span>
-                </div>
+              <LinkBox
+                title="Leavenworth Library"
+                text="Spend your afternoons at the library reading, doing homework, and playing games."
+                subtext="For responsible children who can work independently. Tuesday thru Friday."
+                link="https://www.ncwlibraries.org/locations/leavenworth-public-library/"
+                icon="book"
+                external={false}
+              />
+              <div class="absolute top-2 right-2">
+                <span class="status-badge status-badge--blue status-badge--md">Ongoing</span>
               </div>
+            </div>
             <div class="relative">
               <LinkBox
                 title="Ski Club"
                 text="Weekly skiing program for students to develop skills and enjoy winter sports in the beautiful Cascade Mountains."
-                subtext="Coming Wednesdays January/February 2026. Equipment, transportation to ski hill, and LWSC passes provided. Details to be announced in December."
+                subtext="Wednesdays January/February. Equipment, transportation to ski hill, and LWSC passes provided. Details announced in December."
                 link="#"
                 icon="ac_unit"
                 external={false}
@@ -328,7 +348,7 @@ import Disclaimer from '../../components/ui/Disclaimer.astro';
               <LinkBox
                 title="School Play"
                 text="Theater program where students can explore acting, singing, and stagecraft in a collaborative production."
-                subtext="Coming Spring 2026. Auditions and rehearsals to be announced."
+                subtext="Auditions and rehearsals to be announced in late winter."
                 link="#"
                 icon="theater_comedy"
                 external={false}

--- a/src/pages/things-to-do.astro
+++ b/src/pages/things-to-do.astro
@@ -30,6 +30,7 @@ import Accordian from '../components/ui/Accordian.astro';
         <QuickNavItem title="Community" link="#community" icon="groups" />
         <QuickNavItem title="Volunteering" link="#volunteering" icon="volunteer_activism" />
         <QuickNavItem title="Environmental" link="#environmental" icon="nature" />
+        <QuickNavItem title="Winter Sports" link="#winter-sports" icon="downhill_skiing" />
       </div>
     </div>
 
@@ -39,23 +40,43 @@ import Accordian from '../components/ui/Accordian.astro';
         <SectionHeader
           title="Seasonal Activities"
           icon="calendar_month"
-          text="Current seasonal programs and activities happening this winter."
+          text="Current seasonal programs and activities happening this summer."
         />
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
           <LinkBox
-            title="Plain Valley Adventure Women (PVAW)"
-            text="Join local women for cross-country skiing programs at Plain Valley Ski Trails. Programs include Classic and Skate ski technique sessions, wax clinics, snowshoe community groups, and social events."
-            subtext="Classic Ski (Jan 6-22), Skate Ski (Jan 27-Feb 12). Includes wax clinics, snowshoe group, and community ski days."
-            link="https://www.skiplain.com/pvaw-winter"
-            icon="downhill_skiing"
+            title="Leavenworth Pool"
+            text="Cool off at the Leavenworth community pool. Check the calendar for open swim, lap swim, and other aquatic programs."
+            link="https://leavenworthwa.recdesk.com/Community/Calendar?facilityId=1"
+            icon="pool"
+            external={true}
+          />
+          <div class="flex items-start p-4 bg-white rounded-lg shadow-sm">
+            <span class="material-symbols-outlined text-2xl mr-3 text-gray-600">kayaking</span>
+            <div class="flex-1">
+              <h4 class="font-medium text-gray-900">Raft the Wenatchee</h4>
+              <p class="text-sm text-gray-600">Guided whitewater rafting on the Wenatchee River. Choose from two local outfitters:</p>
+              <div class="mt-2 flex gap-4">
+                <a href="https://www.orionexp.com/?srsltid=AfmBOopZDCZzIxg-Ov7covf-I6emm1OZDVEfURXMMfAWbMM25gSMYuf4" target="_blank" class="text-sm text-blue-600 hover:underline flex items-center gap-1">
+                  Orion Expeditions <span class="material-symbols-outlined text-xs">open_in_new</span>
+                </a>
+                <a href="https://www.riverrider.com/" target="_blank" class="text-sm text-blue-600 hover:underline flex items-center gap-1">
+                  River Rider <span class="material-symbols-outlined text-xs">open_in_new</span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <LinkBox
+            title="Flatwater SUP, Kayak & Tubing"
+            text="Paddle or float the Icicle and Wenatchee Rivers. Rentals and reservations available through Leavenworth Outdoor Center."
+            link="https://leavenworthoutdoorcenter.com/reservations"
+            icon="rowing"
             external={true}
           />
           <LinkBox
-            title="Leavenworth Nordic Clinics"
-            text="Enhance your cross-country skiing skills with clinics offered by the Leavenworth Winter Sports Club at Icicle River Trails. Multi-week and single-day options available for all skill levels."
-            subtext="Multi-week clinics (Jan 6-29) and single-day sessions. Classic and Skate skiing techniques available."
-            link="https://skileavenworth.com/nordic-clinics"
-            icon="snowshoeing"
+            title="Mountain Biking"
+            text="Explore trails in the Leavenworth area. Central Washington Evergreen MTB maintains and maps local singletrack."
+            link="https://cwevergreenmtb.org/trails"
+            icon="pedal_bike"
             external={true}
           />
         </div>
@@ -165,22 +186,6 @@ import Accordian from '../components/ui/Accordian.astro';
               subtext="Facebook community group for local hikers"
               link="https://www.facebook.com/groups/hikeleavenworth/"
               icon="hiking"
-              external={true}
-            />
-            <LinkBox
-              title="Leavenworth Winter Sports Club"
-              text="Cross-country skiing and winter sports club with groomed trails and youth programs"
-              subtext="Cross-country skiing, youth programs, trail passes, winter recreation"
-              link="https://skileavenworth.com/"
-              icon="downhill_skiing"
-              external={true}
-            />
-            <LinkBox
-              title="Plain Valley Ski Trails"
-              text="Cross-country skiing trails with 25km of groomed terrain and youth education programs"
-              subtext="25km groomed trails, youth programs, Valley Pass, Adventure Women programs"
-              link="https://www.skiplain.com/"
-              icon="downhill_skiing"
               external={true}
             />
           </div>
@@ -525,6 +530,51 @@ import Accordian from '../components/ui/Accordian.astro';
               external={true}
             />
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Winter Sports Section -->
+    <div id="winter-sports" class="bg-blue py-8">
+      <div class="w-full px-4 sm:px-6 lg:px-8">
+        <SectionHeader
+          title="Winter Sports"
+          icon="downhill_skiing"
+          text="Cross-country skiing, snowshoeing, and winter recreation in the Leavenworth area."
+        />
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <LinkBox
+            title="Leavenworth Winter Sports Club"
+            text="Cross-country skiing and winter sports club with groomed trails and youth programs"
+            subtext="Cross-country skiing, youth programs, trail passes, winter recreation"
+            link="https://skileavenworth.com/"
+            icon="downhill_skiing"
+            external={true}
+          />
+          <LinkBox
+            title="Plain Valley Ski Trails"
+            text="Cross-country skiing trails with 25km of groomed terrain and youth education programs"
+            subtext="25km groomed trails, youth programs, Valley Pass, Adventure Women programs"
+            link="https://www.skiplain.com/"
+            icon="downhill_skiing"
+            external={true}
+          />
+          <LinkBox
+            title="Plain Valley Adventure Women (PVAW)"
+            text="Join local women for cross-country skiing programs at Plain Valley Ski Trails. Programs include Classic and Skate ski technique sessions, wax clinics, snowshoe community groups, and social events."
+            subtext="Classic Ski and Skate Ski sessions. Includes wax clinics, snowshoe group, and community ski days."
+            link="https://www.skiplain.com/pvaw-winter"
+            icon="downhill_skiing"
+            external={true}
+          />
+          <LinkBox
+            title="Leavenworth Nordic Clinics"
+            text="Enhance your cross-country skiing skills with clinics offered by the Leavenworth Winter Sports Club at Icicle River Trails. Multi-week and single-day options available for all skill levels."
+            subtext="Multi-week clinics and single-day sessions. Classic and Skate skiing techniques available."
+            link="https://skileavenworth.com/nordic-clinics"
+            icon="snowshoeing"
+            external={true}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **things-to-do**: Swaps the seasonal section from nordic skiing to summer activities (pool, rafting via Orion Expeditions & River Rider, flatwater SUP/kayak/tubing, mountain biking); moves all winter/nordic content into a new Winter Sports section with its own quick nav chip
- **after-school-activities**: Replaces per-card "OPEN" badges with season labels; adds an amber callout at the top for upcoming/open signups; updates PVNT to reflect the summer/fall roller ski session and name all three schools (PD, Alpine Lakes, IRMS); clarifies Cub Scouts signup timing (fall best, anytime welcome)

## Test plan
- [ ] Visit `/things-to-do` — confirm summer activities appear at top, Winter Sports section at bottom
- [ ] Visit `/families/after-school-activities` — confirm no "OPEN" badges, amber signup callout visible at top, PVNT shows Summer/Fall badge and lists all three schools

🤖 Generated with [Claude Code](https://claude.com/claude-code)